### PR TITLE
getAssetUrl fix and update to work with new assetMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,12 @@ h.getAssetsForEntryPoint( '/usr/rotunda/my-app/views/page2/page2.js', function( 
 }
 ```
 
-### h.getAssetUrl( assetPath, cb )
+### h.getAssetUrl( assetPath )
 
-Returns the url of the asset with the absolute path `assetPath`. First tries to find the asset in assetMap, then entryPointMap, then finally falls through to return the url of the asset that was at that path at the time cartero was run (an error is thrown if the supplied path does not correspond to an asset of any entry point for which cartero was run.)
+Returns the url of the asset with the absolute path `assetPath` using metaData.json assetMap
 
 ```javascript
-h.getAssetUrl( '/usr/rotunda/my-app/views/page2/photo.png', function( err, asset ) {
-  if( err ) return console.error( err );
-  console.log( asset ); //'url/to/package/img/photo_sha.png'
-}
+h.getAssetUrl( '/usr/rotunda/my-app/views/page2/photo.png') //'url/to/package/img/photo_sha.png'
 ```
 
 ## Contributors
@@ -82,9 +79,9 @@ MIT
 
 ## Change log
 
-### v3.0.0
+### v2.1.0
 
-* Changed `getAssetUrl` to expect a cb (internals are sometimes async so this is required, implementation has changed to first look for asset data in the metaData created by cartero)
+* Changed `getAssetUrl` implementation (looks in asset data in the metaData created by cartero)
 
 ### v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,16 @@ h.getAssetsForEntryPoint( '/usr/rotunda/my-app/views/page2/page2.js', function( 
 }
 ```
 
-### h.getAssetUrl( assetPath )
+### h.getAssetUrl( assetPath, cb )
 
-Returns the url of the asset with the absolute path `assetPath`. (Or more precisely, returns the url of the asset that was at that path at the time cartero was run.) An error is thrown if the supplied path does not correspond to an asset of any entry point for which cartero was run.
+Returns the url of the asset with the absolute path `assetPath`. First tries to find the asset in assetMap, then entryPointMap, then finally falls through to return the url of the asset that was at that path at the time cartero was run (an error is thrown if the supplied path does not correspond to an asset of any entry point for which cartero was run.)
+
+```javascript
+h.getAssetUrl( '/usr/rotunda/my-app/views/page2/photo.png', function( err, asset ) {
+  if( err ) return console.error( err );
+  console.log( asset ); //'url/to/package/img/photo_sha.png'
+}
+```
 
 ## Contributors
 
@@ -74,6 +81,10 @@ Returns the url of the asset with the absolute path `assetPath`. (Or more precis
 MIT
 
 ## Change log
+
+### v3.0.0
+
+* Changed `getAssetUrl` to expect a cb (internals are sometimes async so this is required, implementation has changed to first look for asset data in the metaData created by cartero)
 
 ### v2.0.0
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var _ = require( 'underscore' );
 var kMetaDataFileName = 'metaData.json';
 var kOldPackageMapName = 'package_map.json';
 
-var kMetaDataFormatVersion = 2;
+var kMetaDataFormatVersion = 3;
 
 module.exports = CarteroNodeHook;
 
@@ -82,34 +82,9 @@ CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb 
 
 CarteroNodeHook.prototype.getAssetUrl = function( assetSrcPath, cb ) {
 	var _this = this;
-	//var deprecationError = 'Deprecation warning: CarteroNodeHook getAssetUrl fn is now async, please pass it a cb for updated behavior';
-
-	var attachOutputDir = function( assetPath ) {
-		return ( _this.outputDirUrl && assetPath ) ? path.join( _this.outputDirUrl, assetPath ) : assetPath;
-	};
 
 	var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[ assetSrcPath ];
-	if( assetPath ) {
-		cb( null, attachOutputDir( assetPath ) );
-	} else { //assetSrcPath not found in metaData.assetMap, fall through to getAssetsForEntryPoint
-			this.getAssetsForEntryPoint( assetSrcPath, function( err, parcelAssets ) {
-				if( err ) { //fall through finally to pathMapper
-					var assetPath = pathMapper( assetSrcPath, function( srcDir ) { //not async
-						srcDir = _this.getPackageMapKeyFromPath( srcDir );
-						return _this.metaData.packageMap[ srcDir ] ? '/' + _this.metaData.packageMap[ srcDir ] : null; // return val of dstDir needs to be absolute path
-					});
-					var e;
-					if( assetPath === assetSrcPath ) { //TODO
-						e = 'Could not find url for that asset using pathMapper.';
-						throw new Error( e );
-					}
-					cb( e, attachOutputDir( scriptPath ) );
-				} else {
-					var scriptPath = parcelAssets.script && parcelAssets.script[ 0 ];
-					cb( null, attachOutputDir( scriptPath ) );
-				}
-			} );
-	}
+  return _this.outputDirUrl && assetPath ? path.join( _this.outputDirUrl, assetPath ) : assetPath;
 };
 
 CarteroNodeHook.prototype.getPackageMapKeyFromPath = function( packagePath ) {

--- a/index.js
+++ b/index.js
@@ -50,12 +50,14 @@ CarteroNodeHook.prototype.getTagsForEntryPoint = function( entryPointPath, cb ) 
 	} );
 };
 
-CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb ) {
+CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointDir, cb ) {
 	var _this = this;
 
 	if( ! _this.cache ) this.metaData = this.getMetaData();
 
-	var parcelId = this.metaData.entryPointMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ];
+  //TODO fix this.
+  //var parcelId = this.metaData.entryPointMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ] || this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointDir ) ]; //fallback to packageMap if not in entryPointMap, there are some duped info TODO
+  var parcelId = this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointDir ) ]; //why not??
 	if( ! parcelId ) return cb( new Error( 'Could not find assets for entry point with absolute path "' + entryPointPath + '"' ) );
 
 	if( _this.cache && this.parcelAssetsCache[ parcelId ] )
@@ -74,21 +76,28 @@ CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb 
 	}
 };
 
-CarteroNodeHook.prototype.getAssetUrl = function( assetSrcAbsPath ) {
+CarteroNodeHook.prototype.getAssetUrl = function( assetSrcPath ) {
 	var _this = this;
 
-	var url = pathMapper( assetSrcAbsPath, function( srcDir ) {
-		srcDir = _this.getPackageMapKeyFromPath( srcDir );
-		return _this.metaData.packageMap[ srcDir ] ? '/' + _this.metaData.packageMap[ srcDir ] : null; // return val of dstDir needs to be absolute path
-	} );
+  var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[assetSrcPath];
+  if (!assetPath) throw new Error('asset not found in metaData.assetMap');
+  //var assetDir = path.dirname(assetSrcAbsPath); //not right--still need to find fingerprint dir and replace first dir with it
 
-	if( url === assetSrcAbsPath )
-		throw new Error( 'Could not find url for that asset.' );
+  //var assetDir = pathMapper( assetSrcAbsPath, function( srcDir ) {
+    //debugger;
 
-	if( _this.outputDirUrl )
-		url = path.join( _this.outputDirUrl, url );
+    ////srcDir = _this.getPackageMapKeyFromPath( srcDir );
+    ////return _this.metaData.assetMap[ srcDir ] ? '/' + _this.metaData.assetMap[ srcDir ] : null; // return val of dstDir needs to be absolute path
+    //return _this.metaData.packageMap[srcDir]; // return val of dstDir needs to be absolute path
+  //} );
 
-	return url;
+  //if( assetDir === assetSrcAbsPath ) throw new Error( 'Could not find url for that asset.' );
+
+  //var assetUrl = path.join('/', assetDir, assetFileName);
+
+  if( _this.outputDirUrl ) assetPath = path.join( _this.outputDirUrl, assetPath );
+
+	return assetPath;
 };
 
 CarteroNodeHook.prototype.getPackageMapKeyFromPath = function( packagePath ) {
@@ -114,4 +123,4 @@ CarteroNodeHook.prototype.getMetaData = function() {
 	}
 
 	return metaData;
-}
+};

--- a/index.js
+++ b/index.js
@@ -82,10 +82,10 @@ CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb 
 	}
 };
 
-CarteroNodeHook.prototype.getAssetUrl = function( assetSrcPath, cb ) {
+CarteroNodeHook.prototype.getAssetUrl = function( assetSrcAbsPath) {
 	var _this = this;
 
-	var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[ assetSrcPath ];
+	var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[ assetSrcAbsPath ];
   return _this.outputDirUrl && assetPath ? path.join( _this.outputDirUrl, assetPath ) : assetPath;
 };
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function CarteroNodeHook( outputDirPath, options ) {
 		outputDirUrl : '/',
 		cache : true
 	} );
-	
+
 	this.appRootDir = options.appRootDir;
 	this.outputDirPath = path.resolve( path.dirname( require.main.filename ), outputDirPath );
 	this.outputDirUrl = options.outputDirUrl;
@@ -50,14 +50,15 @@ CarteroNodeHook.prototype.getTagsForEntryPoint = function( entryPointPath, cb ) 
 	} );
 };
 
-CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointDir, cb ) {
+CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb ) { //entryPointPath can be dir or path (that may end in .js)
 	var _this = this;
 
 	if( ! _this.cache ) this.metaData = this.getMetaData();
 
-  //TODO fix this.
-  //var parcelId = this.metaData.entryPointMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ] || this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointDir ) ]; //fallback to packageMap if not in entryPointMap, there are some duped info TODO
-  var parcelId = this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointDir ) ]; //why not??
+  if (/.+\.js$/.test(entryPointPath)) entryPointPath = path.dirname(entryPointPath);
+  var parcelId = this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ];
+  //parcelId = this.metaData.entryPointMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ]; //same result as above, just with the client.js on the end--can just lookup in packagemap right?
+
 	if( ! parcelId ) return cb( new Error( 'Could not find assets for entry point with absolute path "' + entryPointPath + '"' ) );
 
 	if( _this.cache && this.parcelAssetsCache[ parcelId ] )
@@ -80,20 +81,7 @@ CarteroNodeHook.prototype.getAssetUrl = function( assetSrcPath ) {
 	var _this = this;
 
   var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[assetSrcPath];
-  if (!assetPath) throw new Error('asset not found in metaData.assetMap');
-  //var assetDir = path.dirname(assetSrcAbsPath); //not right--still need to find fingerprint dir and replace first dir with it
-
-  //var assetDir = pathMapper( assetSrcAbsPath, function( srcDir ) {
-    //debugger;
-
-    ////srcDir = _this.getPackageMapKeyFromPath( srcDir );
-    ////return _this.metaData.assetMap[ srcDir ] ? '/' + _this.metaData.assetMap[ srcDir ] : null; // return val of dstDir needs to be absolute path
-    //return _this.metaData.packageMap[srcDir]; // return val of dstDir needs to be absolute path
-  //} );
-
-  //if( assetDir === assetSrcAbsPath ) throw new Error( 'Could not find url for that asset.' );
-
-  //var assetUrl = path.join('/', assetDir, assetFileName);
+  if (!assetPath) throw new Error('asset ' + assetSrcPath + ' not found in metaData.assetMap');
 
   if( _this.outputDirUrl ) assetPath = path.join( _this.outputDirUrl, assetPath );
 

--- a/index.js
+++ b/index.js
@@ -50,11 +50,12 @@ CarteroNodeHook.prototype.getTagsForEntryPoint = function( entryPointPath, cb ) 
 	} );
 };
 
-CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb ) { //entryPointPath can be dir or path (that may end in .js)
+CarteroNodeHook.prototype.getAssetsForEntryPoint = function( entryPointPath, cb ) {
 	var _this = this;
 
 	if( ! _this.cache ) this.metaData = this.getMetaData();
 
+	//TODO perhaps impl so entryPointPath can be dir OR path (that may end in an ext such as .js)?
 	//if using packageMap instead of entryPoint (with option to be dir or entryPoint):
 	//if (path.extname(entryPointPath)) entryPointPath = path.dirname(entryPointPath); //test for an extension
 	//var parcelId = this.metaData.packageMap[ _this.getPackageMapKeyFromPath( entryPointPath ) ];
@@ -90,8 +91,7 @@ CarteroNodeHook.prototype.getAssetUrl = function( assetSrcPath, cb ) {
 	var assetPath = _this.metaData.assetMap && _this.metaData.assetMap[ assetSrcPath ];
 	if( assetPath ) {
 		cb( null, attachOutputDir( assetPath ) );
-	} else {
-		//console.log('asset ' + assetSrcPath + ' not found in metaData.assetMap, falling through first to getAssetsForEntryPoint
+	} else { //assetSrcPath not found in metaData.assetMap, fall through to getAssetsForEntryPoint
 			this.getAssetsForEntryPoint( assetSrcPath, function( err, parcelAssets ) {
 				if( err ) { //fall through finally to pathMapper
 					var assetPath = pathMapper( assetSrcPath, function( srcDir ) { //not async

--- a/test/example3/static/assets/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png
+++ b/test/example3/static/assets/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png
@@ -1,0 +1,1 @@
+I'm definitely a photo

--- a/test/example3/static/assets/metaData.json
+++ b/test/example3/static/assets/metaData.json
@@ -1,5 +1,5 @@
 {
-	"formatVersion" : 2,
+	"formatVersion" : 3,
 	"entryPointMap" : {
 	    "/my/fake/abs/path/page1/page1.js": "b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca",
 	    "/my/fake/abs/path/page2/page2.js": "ea7138e6b6eea6321eb1926e8ac88d65f16aa51d"

--- a/test/example3/static/assets/metaData.json
+++ b/test/example3/static/assets/metaData.json
@@ -7,5 +7,8 @@
 	"packageMap" : {
 	    "/my/fake/abs/path/page1": "b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca",
 	    "/my/fake/abs/path/page2": "ea7138e6b6eea6321eb1926e8ac88d65f16aa51d"
-	}
+	},
+  "assetMap": {
+    "/my/fake/abs/path/page2/img/photo.png": "ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png"
+  }
 }

--- a/test/example3/views/page2/img/photo.png
+++ b/test/example3/views/page2/img/photo.png
@@ -1,0 +1,1 @@
+I'm definitely a photo

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ test( 'throw errors when required options are missing', function( t ) {
 } );
 
 test( 'example3', function( t ) {
-	t.plan( 4 );
+	t.plan( 3 );
 
 	var hook = new CarteroNodeHook(
 		path.join( __dirname, "example3/static/assets" ),
@@ -40,9 +40,6 @@ test( 'example3', function( t ) {
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_da3d062d2f431a76824e044a5f153520dad4c697.css"></link>' );
 	} );
 
-	hook.getAssetUrl( '/my/fake/abs/path/page1/page1.js', function( err, result ) {
-		t.deepEqual( result, '/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_14d030e0e64ea9a1fced71e9da118cb29caa6676.js' );
-	} );
 } );
 
 test( 'example3 (no baseUrl)', function( t ) {
@@ -68,19 +65,9 @@ test( 'example3 (no baseUrl)', function( t ) {
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_182694e4a327db0056cfead31f2396287b7d4544.css"></link>' );
 	} );
 
-	hook.getAssetUrl( '/my/fake/abs/path/page2/page2.js', function( err, result ) {
-		t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_5066f9594b8be17fd6360e23df52ffe750206020.js' );
-	} );
+	var asset = hook.getAssetUrl( '/my/fake/abs/path/page2/img/photo.png' );
+	t.deepEqual( asset, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
 
-	hook.getAssetUrl( '/my/fake/abs/path/page2/img/photo.png', function( err, result ) {
-		if ( err ) console.log( err );
-		t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
-	} );
-
-	//TODO eventually test the unhappy pathMapper path (photo doesn't exist), implementation must be made to add the fingerprinted img
-	//hook.getAssetUrl( '/my/fake/abs/path/page1/img/photo.png', function( err, result ) {
-	//if ( err )	console.log( 'err: ',err );
-	//console.log( 'res: ',result );
-	//t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
-	//} );
+	var nonexistentAsset = hook.getAssetUrl( '/my/fake/abs/path/page1/img/photo.png' );
+	t.deepEqual( nonexistentAsset, undefined );
 } );

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,9 @@ test( 'example3', function( t ) {
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_da3d062d2f431a76824e044a5f153520dad4c697.css"></link>' );
 	} );
 
-	t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page1/page1.js' ), '/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1.js' );
+  //TODO
+  t.deepEqual('', '');
+	//t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page1/page1.js' ), '/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1.js' );
 } );
 
 test( 'example3 (no baseUrl)', function( t ) {
@@ -61,10 +63,12 @@ test( 'example3 (no baseUrl)', function( t ) {
 
 	hook.getTagsForEntryPoint( '/my/fake/abs/path/page2/page2.js', function( err, scriptTags, styleTags ) {
 		if( err ) throw err;
-	
+
 		t.deepEqual( scriptTags, '<script type="text/javascript" src="/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_5066f9594b8be17fd6360e23df52ffe750206020.js"></script>' );
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_182694e4a327db0056cfead31f2396287b7d4544.css"></link>' );
 	} );
 
-	t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page2/page2.js' ), '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2.js' );
+  //TODO
+  t.deepEqual('', '');
+	//t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page2/page2.js' ), '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2.js' );
 } );

--- a/test/test.js
+++ b/test/test.js
@@ -73,14 +73,14 @@ test( 'example3 (no baseUrl)', function( t ) {
 	} );
 
 	hook.getAssetUrl( '/my/fake/abs/path/page2/img/photo.png', function( err, result ) {
-		if (err) console.log(err);
+		if ( err ) console.log( err );
 		t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
 	} );
 
 	//TODO eventually test the unhappy pathMapper path (photo doesn't exist), implementation must be made to add the fingerprinted img
 	//hook.getAssetUrl( '/my/fake/abs/path/page1/img/photo.png', function( err, result ) {
-	//if (err)	console.log('err: ',err);
-	//console.log('res: ',result);
+	//if ( err )	console.log( 'err: ',err );
+	//console.log( 'res: ',result );
 	//t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
 	//} );
 } );

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ test( 'example3', function( t ) {
 		t.deepEqual( result, {
 			script : [ 'b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_14d030e0e64ea9a1fced71e9da118cb29caa6676.js' ],
 			style : [ 'b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_da3d062d2f431a76824e044a5f153520dad4c697.css' ] }
-		);
+							 );
 	} );
 
 	hook.getTagsForEntryPoint( '/my/fake/abs/path/page1/page1.js', function( err, scriptTags, styleTags ) {
@@ -40,13 +40,13 @@ test( 'example3', function( t ) {
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_da3d062d2f431a76824e044a5f153520dad4c697.css"></link>' );
 	} );
 
-  //TODO
-  t.deepEqual('', '');
-	//t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page1/page1.js' ), '/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1.js' );
+	hook.getAssetUrl( '/my/fake/abs/path/page1/page1.js', function( err, result ) {
+		t.deepEqual( result, '/l/b4ca7610c2ace13dc8d4c9f96eb62b459fcfceca/page1_bundle_14d030e0e64ea9a1fced71e9da118cb29caa6676.js' );
+	} );
 } );
 
 test( 'example3 (no baseUrl)', function( t ) {
-	t.plan( 4 );
+	t.plan( 5 );
 
 	var hook = new CarteroNodeHook(
 		path.join( __dirname, "example3/static/assets" )
@@ -58,7 +58,7 @@ test( 'example3 (no baseUrl)', function( t ) {
 		t.deepEqual( result, {
 			script : [ 'ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_5066f9594b8be17fd6360e23df52ffe750206020.js' ],
 			style : [ 'ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_182694e4a327db0056cfead31f2396287b7d4544.css' ] }
-		);
+							 );
 	} );
 
 	hook.getTagsForEntryPoint( '/my/fake/abs/path/page2/page2.js', function( err, scriptTags, styleTags ) {
@@ -68,7 +68,19 @@ test( 'example3 (no baseUrl)', function( t ) {
 		t.deepEqual( styleTags, '<link rel="stylesheet" href="/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_182694e4a327db0056cfead31f2396287b7d4544.css"></link>' );
 	} );
 
-  //TODO
-  t.deepEqual('', '');
-	//t.deepEqual( hook.getAssetUrl( '/my/fake/abs/path/page2/page2.js' ), '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2.js' );
+	hook.getAssetUrl( '/my/fake/abs/path/page2/page2.js', function( err, result ) {
+		t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/page2_bundle_5066f9594b8be17fd6360e23df52ffe750206020.js' );
+	} );
+
+	hook.getAssetUrl( '/my/fake/abs/path/page2/img/photo.png', function( err, result ) {
+		if (err) console.log(err);
+		t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
+	} );
+
+	//TODO eventually test the unhappy pathMapper path (photo doesn't exist), implementation must be made to add the fingerprinted img
+	//hook.getAssetUrl( '/my/fake/abs/path/page1/img/photo.png', function( err, result ) {
+	//if (err)	console.log('err: ',err);
+	//console.log('res: ',result);
+	//t.deepEqual( result, '/ea7138e6b6eea6321eb1926e8ac88d65f16aa51d/img/photo_sha.png' );
+	//} );
 } );


### PR DESCRIPTION
Update `getAssetUrl` to work with fingerprinted assets - checks for the asset in `assetMap`.

Tests added.

parallel cartero PR:  https://github.com/rotundasoftware/cartero/pull/46

@ferlores @dgbeck 
