### PR TITLE
remove link end tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ CarteroNodeHook.prototype.getTagsForEntryPoint = function( entryPointPath, cb ) 
 		} ).join( '\n' );
 
 		var styleTags = assetUrls.style.map( function( assetPath ) {
-			return '<link rel="stylesheet" href="' + url.resolve( _this.outputDirUrl, assetPath ) + '"></link>';
+			return '<link rel="stylesheet" href="' + url.resolve( _this.outputDirUrl, assetPath ) + '">';
 		} ).join( '\n' );
 
 		cb( null, scriptTags, styleTags );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartero-node-hook",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Node hook to get the list of assets required by a cartero parcel.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi @dgbeck, can you review and merge this one. Remove the end tag for `link`.

https://www.w3.org/TR/html5/document-metadata.html#the-link-element

Thx!

